### PR TITLE
Image & Deploy Improvements

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-erlang 23.2.6
-elixir 1.11.3
+erlang 22.3.4.16
+elixir 1.11.1-otp-22
 python 3.8.5

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-erlang 22.3.3
-elixir 1.10.3-otp-22
+erlang 23.2.6
+elixir 1.11.3
 python 3.8.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.11.0-erlang-21.3.8.21-alpine-3.13.1 as builder
+FROM hexpm/elixir:1.11.3-erlang-23.2.6-alpine-3.13.2 as builder
 
 WORKDIR /root
 
@@ -19,7 +19,7 @@ WORKDIR /root
 RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, compile, distillery.release --verbose
 
 # Second stage: uses the built .tgz to get the files over
-FROM alpine:3.13.1
+FROM alpine:3.13.2
 
 RUN apk add --update libssl1.1 ncurses-libs bash \
 	&& rm -rf /var/cache/apk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10-alpine as builder
+FROM hexpm/elixir:1.11.0-erlang-21.3.8.21-alpine-3.13.1 as builder
 
 WORKDIR /root
 
@@ -19,7 +19,7 @@ WORKDIR /root
 RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, compile, distillery.release --verbose
 
 # Second stage: uses the built .tgz to get the files over
-FROM alpine:3.11
+FROM alpine:3.13.1
 
 RUN apk add --update libssl1.1 ncurses-libs bash \
 	&& rm -rf /var/cache/apk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.11.3-erlang-23.2.6-alpine-3.13.2 as builder
+FROM hexpm/elixir:1.11.1-erlang-22.3.4.16-alpine-3.13.1 as builder
 
 WORKDIR /root
 
@@ -19,7 +19,7 @@ WORKDIR /root
 RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, compile, distillery.release --verbose
 
 # Second stage: uses the built .tgz to get the files over
-FROM alpine:3.13.2
+FROM alpine:3.13.1
 
 RUN apk add --update libssl1.1 ncurses-libs bash \
 	&& rm -rf /var/cache/apk

--- a/semaphore/deploy.sh
+++ b/semaphore/deploy.sh
@@ -15,7 +15,16 @@ githash=$(git rev-parse --short HEAD)
 # get JSON describing task definition currently running on AWS
 # use it as basis for new revision, but replace image with the one built above
 taskdefinition=$(aws ecs describe-task-definition --region us-east-1 --task-definition $awsenv)
-taskdefinition=$(echo $taskdefinition | jq ".taskDefinition | del(.status) | del(.taskDefinitionArn) | del(.requiresAttributes) | del(.revision) | del(.compatibilities)")
+taskdefinition=$(echo $taskdefinition | \
+                 jq ".taskDefinition |
+                     del(.status) |
+                     del(.taskDefinitionArn) |
+                     del(.requiresAttributes) |
+                     del(.revision) |
+                     del(.compatibilities) |
+                     del(.registeredBy) |
+                     del(.registeredAt)
+                 ")
 newcontainers=$(echo $taskdefinition | jq ".containerDefinitions | map(.image=\"$DOCKER_REPO:git-$githash\")")
 aws ecs register-task-definition --region us-east-1 --family $awsenv --cli-input-json "$taskdefinition" --container-definitions "$newcontainers"
 newrevision=$(aws ecs describe-task-definition --region us-east-1 --task-definition $awsenv | jq '.taskDefinition.revision')

--- a/semaphore/deploy.sh
+++ b/semaphore/deploy.sh
@@ -39,7 +39,7 @@ function exit_if_too_many_checks {
   if [[ $checks -ge 12 ]]; then
     exit 1
   fi
-  sleep 5
+  sleep 10
   checks=$((checks+1))
 }
 


### PR DESCRIPTION
Asana Tasks:

- [Fix API Checker deployment](https://app.asana.com/0/881264583703207/1199906233124798/f)
- [update api_checker to use hexpm/elixir container](https://app.asana.com/0/1113179098808463/1199910231398959/f)

## Considerations

- Use `hexpm/elixir` base image instead of `elixir`
- Update to Elixir 1.11 and Alpine 13.3
- Resolve deployment errors by removing additional parameters from the exported task definition
- Increase wait time for ECS deployment from 60 to 120 seconds